### PR TITLE
Adds tests quant parsing; Adds unbounded ranges

### DIFF
--- a/commands/commands_suite_test.go
+++ b/commands/commands_suite_test.go
@@ -1,0 +1,13 @@
+package commands_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommands(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Commands Suite")
+}

--- a/commands/quantize.go
+++ b/commands/quantize.go
@@ -1,13 +1,14 @@
 package commands
 
 import (
-	"github.com/pkg/errors"
+	"math"
 	"strconv"
 	"strings"
 
 	"github.com/cirocosta/asciinema-edit/cast"
 	"github.com/cirocosta/asciinema-edit/commands/transformer"
 	"github.com/cirocosta/asciinema-edit/editor"
+	"github.com/pkg/errors"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -80,33 +81,72 @@ func (t *quantizeTransformation) Transform(c *cast.Cast) (err error) {
 	return
 }
 
-func parseQuantizeRanges(ranges []string) (res []editor.QuantizeRange, err error) {
-	res = make([]editor.QuantizeRange, len(ranges))
+// ParseQuantizeRange takes an input string that represents
+// a quantization range and converts it into a QuantizeRange
+// instance.
+//
+// It allows both bounded and unbounded ranges.
+//
+// For instance:
+// - bounded: 1,2
+// - unbounded: 1
+//
+// Fails if the input can't be converted to a QuantizeRange.
+func ParseQuantizeRange(input string) (res editor.QuantizeRange, err error) {
+	cols := strings.Split(input, ",")
 
-	for idx, rangeStr := range ranges {
-		cols := strings.Split(rangeStr, ",")
+	if len(cols) > 2 {
+		err = errors.Errorf(
+			"invalid range format: must be `value[,value]`")
+		return
+	}
 
-		if len(cols) > 2 {
-			err = errors.Errorf(
-				"invalid range format: must be `value[,value]`")
-			return
-		}
-
-		if len(cols) == 2 {
-			res[idx].To, err = strconv.ParseFloat(cols[1], 64)
-			if err != nil {
-				err = errors.Errorf(
-					"malformed range: not a float %s", cols[1])
-				return
-			}
-		}
-
-		res[idx].From, err = strconv.ParseFloat(cols[0], 64)
+	if len(cols) == 2 {
+		res.To, err = strconv.ParseFloat(cols[1], 64)
 		if err != nil {
 			err = errors.Errorf(
-				"malformed range: not a float %s", cols[0])
+				"malformed range: second element is not a float '%s'", cols[1])
 			return
 		}
+	}
+
+	res.From, err = strconv.ParseFloat(cols[0], 64)
+	if err != nil {
+		err = errors.Errorf(
+			"malformed range: first element is not a float '%s'", cols[0])
+		return
+	}
+
+	if res.To == 0 {
+		res.To = math.MaxFloat64
+	}
+
+	if res.To <= res.From {
+		err = errors.Errorf(
+			"constraint not verified: from < to")
+		return
+	}
+
+	return
+}
+
+func parseQuantizeRanges(inputs []string) (ranges []editor.QuantizeRange, err error) {
+	ranges = make([]editor.QuantizeRange, 0)
+
+	var (
+		qRange editor.QuantizeRange
+		input  string
+	)
+
+	for _, input = range inputs {
+		qRange, err = ParseQuantizeRange(input)
+		if err != nil {
+			err = errors.Wrapf(err, "failed to parse range %s",
+				input)
+			return
+		}
+
+		ranges = append(ranges, qRange)
 	}
 
 	return

--- a/commands/quantize.go
+++ b/commands/quantize.go
@@ -121,6 +121,12 @@ func ParseQuantizeRange(input string) (res editor.QuantizeRange, err error) {
 		res.To = math.MaxFloat64
 	}
 
+	if res.From < 0 {
+		err = errors.Errorf(
+			"constraint not verified: from >= 0")
+		return
+	}
+
 	if res.To <= res.From {
 		err = errors.Errorf(
 			"constraint not verified: from < to")

--- a/commands/quantize_test.go
+++ b/commands/quantize_test.go
@@ -1,0 +1,105 @@
+package commands_test
+
+import (
+	"math"
+
+	"github.com/cirocosta/asciinema-edit/commands"
+	"github.com/cirocosta/asciinema-edit/editor"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ParseQuantizeRange", func() {
+	Context("having empty input", func() {
+		var input = ""
+
+		It("fails", func() {
+			_, err := commands.ParseQuantizeRange(input)
+			Expect(err).NotTo(Succeed())
+		})
+	})
+
+	Context("having invalid chars", func() {
+		var input string
+
+		It("fails if non-decimal", func() {
+			input = "1a"
+			_, err := commands.ParseQuantizeRange(input)
+			Expect(err).NotTo(Succeed())
+		})
+
+		It("fails if starts w/ non-numeric", func() {
+			input = "a"
+			_, err := commands.ParseQuantizeRange(input)
+			Expect(err).NotTo(Succeed())
+		})
+
+		It("fails if ends w/ non-numeric", func() {
+			input = "1,a"
+			_, err := commands.ParseQuantizeRange(input)
+			Expect(err).NotTo(Succeed())
+		})
+
+		It("fails with leading comma", func() {
+			input = ",1"
+			_, err := commands.ParseQuantizeRange(input)
+			Expect(err).NotTo(Succeed())
+		})
+
+		It("fails with trailing comma", func() {
+			input = "1,"
+			_, err := commands.ParseQuantizeRange(input)
+			Expect(err).NotTo(Succeed())
+		})
+	})
+
+	Context("having a valid entry", func() {
+		var (
+			input  string
+			qRange editor.QuantizeRange
+			err    error
+		)
+
+		Context("that is unbounded", func() {
+			BeforeEach(func() {
+				input = "1.2"
+				qRange, err = commands.ParseQuantizeRange(input)
+			})
+
+			It("succeeds", func() {
+				Expect(err).To(Succeed())
+			})
+
+			It("starts with lower bound", func() {
+				Expect(qRange.From).To(Equal(float64(1.2)))
+			})
+
+			It("ends with the closes to infinit (max float)", func() {
+				Expect(qRange.To).To(Equal(math.MaxFloat64))
+			})
+		})
+
+		Context("that is bounded with `from > to`", func() {
+			BeforeEach(func() {
+				input = "2,1"
+				qRange, err = commands.ParseQuantizeRange(input)
+			})
+
+			It("fails", func() {
+				Expect(err).ToNot(Succeed())
+			})
+		})
+
+		Context("that is bounded with `from == to`", func() {
+			BeforeEach(func() {
+				input = "2,2"
+				qRange, err = commands.ParseQuantizeRange(input)
+			})
+
+			It("fails", func() {
+				Expect(err).ToNot(Succeed())
+			})
+		})
+	})
+})

--- a/commands/quantize_test.go
+++ b/commands/quantize_test.go
@@ -64,6 +64,9 @@ var _ = Describe("ParseQuantizeRange", func() {
 		Context("that is unbounded", func() {
 			BeforeEach(func() {
 				input = "1.2"
+			})
+
+			JustBeforeEach(func() {
 				qRange, err = commands.ParseQuantizeRange(input)
 			})
 
@@ -77,6 +80,16 @@ var _ = Describe("ParseQuantizeRange", func() {
 
 			It("ends with the closes to infinit (max float)", func() {
 				Expect(qRange.To).To(Equal(math.MaxFloat64))
+			})
+
+			Context("with negative lower bound", func() {
+				BeforeEach(func() {
+					input = "-1.2"
+				})
+
+				It("fails", func() {
+					Expect(err).ToNot(Succeed())
+				})
 			})
 		})
 

--- a/editor/quantize.go
+++ b/editor/quantize.go
@@ -16,22 +16,6 @@ type QuantizeRange struct {
 	To float64
 }
 
-// NewQuantizeRange creates a new quantize range performing some basic
-// validations:
-// - `from` < `to`
-func NewQuantizeRange(from, to float64) (q *QuantizeRange, err error) {
-	if from < to {
-		err = errors.Errorf("constraint not satisfied: from < to")
-		return
-	}
-
-	q = &QuantizeRange{
-		From: from,
-		To:   to,
-	}
-	return
-}
-
 // InRange verifies whether a given value lies within the quantization
 // range.
 func (q *QuantizeRange) InRange(value float64) bool {


### PR DESCRIPTION
#2 

---

```
commit 1f94258d9b3691b057595b6030f869911147b194

  Previously it wasn't possible to make use of unbounded ranges in the
  CLI: --range 1 would be equivalent to --range 1,0.
  After this comming, such ranges are possible: --range 1 is equivalente
  to --range 1,math.MathFloat64.

  The commit also adds tests for the parsing method given that it's not
  trivial.

commit fe04829d7724a0734c8fcd2ae97442a460b2e536  
  Applies negative value constraint to range parse
```