### PR TITLE
Fixes wrong json key name (idletimelimit)

### DIFF
--- a/cast/cast.go
+++ b/cast/cast.go
@@ -65,7 +65,7 @@ type Header struct {
 
 	// IdleTimeLimit specifies the maximum amount of idleness between
 	// one command and another.
-	IdleTimeLimit float64 `json:"title,omitempty"`
+	IdleTimeLimit float64 `json:"idle_time_limit,omitempty"`
 
 	// Env specifies a map of environment variables captured by the
 	// asciinema command.

--- a/cast/cast_test.go
+++ b/cast/cast_test.go
@@ -383,7 +383,7 @@ var _ = Describe("Cast", func() {
 				)
 
 				BeforeEach(func() {
-					reader = bytes.NewBufferString(`{"version": 2, "width":123}
+					reader = bytes.NewBufferString(`{"version": 2, "width":123, "idle_time_limit": 1, "timestamp": 2, "command": "/bin/sh", "title": "test", "env": {"SHELL": "/bin/sh", "TERM": "a-term256"}, "theme": { "fg": "#aaa", "bg":"#bbb", "palette": "a,b,c" }}
 [1,"o", "lol"]
 [2,"o", "lol"]`)
 					decodedCast, err = cast.Decode(reader)


### PR DESCRIPTION
- Fixes `idle_time_limit` parsing; and
- Updates cast decoding test to include all optional fields.

---

#8 