### PR TITLE
Indent usage in help to make commands stand out

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"io"
 	"os"
+	"strings"
 
+	"github.com/Masterminds/sprig"
 	"github.com/cirocosta/asciinema-edit/commands"
 	"gopkg.in/urfave/cli.v1"
 )
@@ -12,7 +15,23 @@ var (
 	commit  = "HEAD"
 )
 
+var CmdHelpOld = `COMMANDS:{{range .VisibleCategories}}{{if .Name}}
+   {{.Name}}:{{end}}{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}`
+
+var CmdHelpNew = `COMMANDS:{{range .VisibleCommands}}
+
+{{.Name}}
+
+  {{.Usage | indent 2}}{{end}}
+`
+
 func main() {
+	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+		cli.HelpPrinterCustom(w, templ, data, sprig.FuncMap())
+	}
+	cli.AppHelpTemplate = strings.Replace(cli.AppHelpTemplate, CmdHelpOld, CmdHelpNew, 1)
+
 	app := cli.NewApp()
 
 	app.Version = version + " - " + commit


### PR DESCRIPTION
Right now, the `quantize` command help starts as this.
```
   Remove the exact frame at timestamp 12.2 from the cast file named
   1234.cast.

     asciinema-edit cut \
       --start=12.2 --end=12.2 \
       1234.cast
     quantize  Updates the cast delays following quantization ranges.

   The command acts on the delays between the frames, reducing such
   timings to the lowest value defined in a given range that they
   lie in.
```
This PR fixes that.

Uses https://github.com/urfave/cli/blob/master/docs/v1/manual.md#generated-help-text and `sprig` helper for indentation. `fmt.Println(cli.AppHelpTemplate)` was used to get actual template text for replacement.