### PR TITLE
doc/typo: setting the correct --end flag on the helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ EXAMPLES:
      asciinema-edit speed \
         --factor 2 \
         --start 12.231 \
-        --factor 45.333 \
+        --end 45.333 \
         ./123.cast
 
 USAGE:

--- a/commands/speed.go
+++ b/commands/speed.go
@@ -35,7 +35,7 @@ EXAMPLES:
      asciinema-edit speed \
         --factor 2 \
         --start 12.231 \
-        --factor 45.333 \
+        --end 45.333 \
         ./123.cast`,
 	ArgsUsage: "[filename]",
 	Action:    speedAction,


### PR DESCRIPTION
Removing duplicated `--fator` flag, replacing to the `--end` on the example of editing some part of the video.