### PR TITLE
Improve install instructions via go

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Having those, you can improve your cast by:
 
 ### Installation
 
-Being a Golang application, you can either build it yourself with `go get` or fetch a specific version from the [Releases page](https://github.com/cirocosta/asciinema-edit/releases):
+Being a Golang application, you can either build it yourself with `go install` or fetch a specific version from the [Releases page](https://github.com/cirocosta/asciinema-edit/releases):
 
 ```sh
 #Using `go`, fetch the latest from `master`
-go get -u -v github.com/cirocosta/asciinema-edit
+go install github.com/cirocosta/asciinema-edit@latest
 
 #Retrieving from GitHub releases
 VERSION=0.0.6


### PR DESCRIPTION
I followed the install instructions:
```
$ go get -u -v github.com/cirocosta/asciinema-edit
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

So I tried again with `go install github.com/cirocosta/asciinema-edit@latest`, which works. Therefore I propose to change the README to that.